### PR TITLE
enable slew-rate control to prevent overcurrent

### DIFF
--- a/tgy.asm
+++ b/tgy.asm
@@ -163,7 +163,7 @@
 .equ	MOTOR_REVERSE	= 0	; Reverse normal commutation direction
 .equ	RC_PULS_REVERSE	= 0	; Enable RC-car style forward/reverse throttle
 .equ	RC_CALIBRATION	= 0	; Support run-time calibration of min/max pulse lengths
-.equ	SLOW_THROTTLE	= 0	; Limit maximum throttle jump to try to prevent overcurrent
+.equ	SLOW_THROTTLE	= 1	; Limit maximum throttle jump to try to prevent overcurrent
 .equ	BEACON		= 0	; Beep periodically when RC signal is lost
 .if !defined(CHECK_HARDWARE)
 .equ	CHECK_HARDWARE	= 0	; Check for correct pin configuration, sense inputs, and functioning MOSFETs


### PR DESCRIPTION
### Slew-rate limited

![slew_rate1](https://cloud.githubusercontent.com/assets/3289118/9641866/cda2bb10-516d-11e5-96b7-737c18e8e1dd.png)
### No slew-rate (v1.0.0 software)

![slew_rate3](https://cloud.githubusercontent.com/assets/3289118/9641868/cddaed96-516d-11e5-9766-ca0e8294cf6d.png)
![slew_rate2](https://cloud.githubusercontent.com/assets/3289118/9641867/cdc39fba-516d-11e5-9b6c-d4db8bd1dae1.png)
